### PR TITLE
feat: waste list update allow in front end and back end

### DIFF
--- a/src/Redux/features/modalWaste/modalWasteSlice.js
+++ b/src/Redux/features/modalWaste/modalWasteSlice.js
@@ -1,0 +1,18 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  modalEditWasteOpen: false,
+};
+
+const modalWasteSlice = createSlice({
+  name: "modalWaste",
+  initialState,
+  reducers: {
+    setEditWasteModal: (state, action) => {
+      state.modalEditWasteOpen = action.payload;
+    },
+  },
+});
+
+export const { setEditWasteModal } = modalWasteSlice.actions;
+export default modalWasteSlice.reducer;

--- a/src/Redux/features/user/userSlice.js
+++ b/src/Redux/features/user/userSlice.js
@@ -4,6 +4,7 @@ import {
   updateRequestToApi,
   getUserWasteFromDB,
   createWasteInDB,
+  updateWasteInDB,
 } from "../../../api/userAPI";
 import { userWasteList } from "../../mockData/myWasteList";
 import { userPacaList } from "../../mockData/myPacaList";
@@ -21,6 +22,7 @@ const initialState = {
   myPacaList: userPacaList,
   thunkValidation: "",
   myLocation: [4.653251013860561, -74.08372879028322],
+  selectedAlertId: "",
 };
 
 // get data from API with thunk and a helper function fetchCocktails
@@ -59,12 +61,24 @@ export const createWasteAsync = createAsyncThunk(
   }
 );
 
+export const updateWasteAsync = createAsyncThunk(
+  "user/updateWaste",
+  async (reqBody, thunkAPI) => {
+    const id = thunkAPI.getState().user.userId;
+    const data = await updateWasteInDB(reqBody, id);
+    return data;
+  }
+);
+
 const userSlice = createSlice({
   name: "userInfo",
   initialState,
   reducers: {
     setUserId: (state, action) => {
       state.userId = action.payload;
+    },
+    setSelectedAlertId: (state, action) => {
+      state.selectedAlertId = action.payload;
     },
     setMyUsername: (state, action) => {
       state.myUsername = action.payload;
@@ -134,6 +148,13 @@ const userSlice = createSlice({
       })
       .addCase(createWasteAsync.rejected, (state, action) => {
         console.log("createWasteAsync rejected", action.error.message);
+      })
+      .addCase(updateWasteAsync.fulfilled, (state, action) => {
+        state.myWasteList = action.payload;
+        console.log("updateWasteAsync fulfilled", action.payload);
+      })
+      .addCase(updateWasteAsync.rejected, (state, action) => {
+        console.log("updateWasteAsync rejected", action.error.message);
       });
   },
 });
@@ -149,5 +170,6 @@ export const {
   addToMyPacaPost,
   setMyLocation,
   setThunkValidation,
+  setSelectedAlertId,
 } = userSlice.actions;
 export default userSlice.reducer;

--- a/src/Redux/store.js
+++ b/src/Redux/store.js
@@ -2,10 +2,12 @@ import { configureStore } from "@reduxjs/toolkit";
 
 import userReducer from "./features/user/userSlice";
 import generalMapReducer from "./features/generalMap/generalMapSlice";
+import modalWasteReducer from "./features/modalWaste/modalWasteSlice";
 
 export const store = configureStore({
   reducer: {
     user: userReducer,
     generalMap: generalMapReducer,
+    modalWaste: modalWasteReducer,
   },
 });

--- a/src/api/userAPI.js
+++ b/src/api/userAPI.js
@@ -39,7 +39,7 @@ export const updateRequestToApi = async (reqBody, userId) => {
   }
 };
 
-export const getUserWasteFromDB = async (reqBody, userId) => {
+export const getUserWasteFromDB = async (reqBody = "", userId) => {
   try {
     const userWaste = await axios({
       method: "get",
@@ -103,6 +103,39 @@ export const createWasteInDB = async (reqBody, userId) => {
 
     return new Promise((resolve, reject) => {
       resolve(newPost);
+    });
+  } catch (error) {
+    return new Promise((resolve, reject) => {
+      reject(error);
+    });
+  }
+};
+
+export const updateWasteInDB = async (reqBody, userId) => {
+  try {
+    const { location, date, description, deliveryState, wasteId } = reqBody;
+    // avoid modifying the Id in the database
+    const formatedBody = {
+      location,
+      description,
+      date,
+      deliveryState,
+    };
+
+    // 1. update de db with the request
+    await axios({
+      method: "put",
+      url: `${CONFIG_API.DB}/waste/_id/${wasteId}`,
+      data: formatedBody,
+      withCredentials: true, //will send the token from the cookies
+    });
+
+    // 2. get the updated list from theAPI
+    const updatedList = await getUserWasteFromDB("", userId);
+    console.log("secon request response>>", updatedList);
+
+    return new Promise((resolve, reject) => {
+      resolve(updatedList);
     });
   } catch (error) {
     return new Promise((resolve, reject) => {

--- a/src/components/DataSet/Amigo/TableAmigo/EditWaste/EditWaste.jsx
+++ b/src/components/DataSet/Amigo/TableAmigo/EditWaste/EditWaste.jsx
@@ -1,0 +1,47 @@
+/* eslint-disable no-unused-vars */
+import { Box, Button, Modal } from "@mui/material";
+import { useDispatch, useSelector } from "react-redux";
+import { setEditWasteModal } from "../../../../../Redux/features/modalWaste/modalWasteSlice";
+import FormEditWaste from "./FormEditWaste";
+
+function EditWaste() {
+  const { modalEditWasteOpen } = useSelector((store) => store.modalWaste);
+
+  const dispatch = useDispatch();
+
+  const style = {
+    position: "absolute",
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+    width: "auto",
+    bgcolor: "background.paper",
+    border: "secondary",
+    boxShadow: 24,
+    p: 2,
+    overflowY: "scroll",
+    maxHeight: "90vh",
+  };
+
+  const handleClose = () => {
+    dispatch(setEditWasteModal(false));
+  };
+
+  return (
+    <>
+      <Modal
+        open={modalEditWasteOpen} //modal open state is handle fro the edit button in the table
+        onClose={handleClose}
+        aria-labelledby="modal-edit-waste"
+        aria-describedby="modal-modal-description"
+      >
+        <Box sx={style}>
+          <Button onClick={handleClose}>Cerrar</Button>
+          <FormEditWaste />
+        </Box>
+      </Modal>
+    </>
+  );
+}
+
+export default EditWaste;

--- a/src/components/DataSet/Amigo/TableAmigo/EditWaste/OpenModalButton.jsx
+++ b/src/components/DataSet/Amigo/TableAmigo/EditWaste/OpenModalButton.jsx
@@ -1,0 +1,19 @@
+import { useDispatch } from "react-redux";
+import { setEditWasteModal } from "../../../../../Redux/features/modalWaste/modalWasteSlice";
+import { Button } from "@mui/material";
+import { PropTypes } from "prop-types";
+import { setSelectedAlertId } from "../../../../../Redux/features/user/userSlice";
+
+function OpenModalButton({ id }) {
+  const dispatch = useDispatch();
+  const handleclick = () => {
+    dispatch(setEditWasteModal(true));
+    dispatch(setSelectedAlertId(id));
+  };
+  return <Button onClick={handleclick}>Editar</Button>;
+}
+
+OpenModalButton.propTypes = {
+  id: PropTypes.string,
+};
+export default OpenModalButton;

--- a/src/components/DataSet/Amigo/TableAmigo/EditWaste/index.js
+++ b/src/components/DataSet/Amigo/TableAmigo/EditWaste/index.js
@@ -1,0 +1,2 @@
+import EditWaste from "./EditWaste";
+export { EditWaste };

--- a/src/components/DataSet/Amigo/TableAmigo/TableAmigo.jsx
+++ b/src/components/DataSet/Amigo/TableAmigo/TableAmigo.jsx
@@ -1,8 +1,10 @@
 // import { PostAmigo } from "../../components/PostAmigo";
-import { Box, Typography, Button } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { DataGrid, GridToolbar } from "@mui/x-data-grid";
 import dayjs from "dayjs";
 import { useSelector } from "react-redux";
+import { EditWaste } from "./EditWaste";
+import OpenModalButton from "./EditWaste/OpenModalButton";
 
 const columns = [
   // { field: "wasteId", headerName: "ID Desecho", flex: 1 },
@@ -19,7 +21,7 @@ const columns = [
     headerName: "Modificar",
     flex: 1,
     renderCell: ({ row: { wasteId } }) => {
-      return <Button id={wasteId}>Editar</Button>;
+      return <OpenModalButton id={wasteId} />;
     },
   },
   {
@@ -35,9 +37,11 @@ const columns = [
 
 function TableAmigo() {
   const { myWasteList } = useSelector((store) => store.user);
+  const { modalEditWasteOpen } = useSelector((store) => store.modalWaste);
 
   return (
     <Box>
+      {modalEditWasteOpen && <EditWaste />}
       <Typography>Mis avisos</Typography>
       <DataGrid
         rows={myWasteList}
@@ -45,15 +49,6 @@ function TableAmigo() {
         getRowId={(row) => row?.wasteId}
         components={{ Toolbar: GridToolbar }}
         disableRowSelectionOnClick
-        // checkboxSelection
-        // initialState={{
-        //   pagination: {
-        //     paginationModel: {
-        //       pageSize: 4,
-        //     },
-        //   },
-        // }}
-        // pageSizeOptions={[4]}
       />
     </Box>
   );


### PR DESCRIPTION
1. edit waste list front end components created.
2. endpoints connected for wastes collections update: user updates data from a form, then after updating the db a new request is make to get the updates list of wastes for a user, finally the list is set a the current waste list for re-rendering the appropriate components.
3. modalSlice was added to handle opening and closing events (for editing waste modal window) from different components.