### PR TITLE
refactor: chat loaded and backup with DB endpoints

### DIFF
--- a/src/Redux/features/user/userSlice.js
+++ b/src/Redux/features/user/userSlice.js
@@ -24,6 +24,8 @@ const initialState = {
   thunkValidation: "",
   myLocation: [4.653251013860561, -74.08372879028322],
   selectedAlertId: "",
+  chatContacts: [],
+  chatConversations: [],
 };
 
 // get data from API with thunk and a helper function fetchCocktails
@@ -137,6 +139,12 @@ const userSlice = createSlice({
           state.userImageUrl = userInfo.userImage;
         }
         state.isLoading = false;
+        if (userInfo.chat.conversations.length) {
+          state.chatConversations = userInfo.chat.conversations;
+        }
+        if (userInfo.chat.contacts.length) {
+          state.chatContacts = userInfo.chat.contacts;
+        }
       })
       .addCase(getUserAsync.rejected, (state, action) => {
         state.isLoading = false;

--- a/src/components/ChatApp/ChatApp.jsx
+++ b/src/components/ChatApp/ChatApp.jsx
@@ -4,10 +4,11 @@ import { ChatDashboard } from "./components/ChatDashboard";
 import { ContactsProvider } from "./contexts/ContactsProvider";
 import { ConversationsProvider } from "./contexts/ConversationsProvider";
 import { SocketProvider } from "./contexts/SocketProvider";
+import { useSelector } from "react-redux";
 
 function ChatApp() {
-  const [id, setId] = useLocalStorage("id", "");
-  // console.log(id);
+  const { userId } = useSelector((store) => store.user);
+  const [id, setId] = useLocalStorage("id", userId);
 
   const chatDashboard = (
     <SocketProvider id={id}>

--- a/src/components/ChatApp/components/ChatDashboard/ChatDashboard.jsx
+++ b/src/components/ChatApp/components/ChatDashboard/ChatDashboard.jsx
@@ -2,15 +2,56 @@
 import { Sidebar } from "../Sidebar";
 import { OpenConversation } from "../OpenConversation";
 import { useConversations } from "../../contexts/ConversationsProvider";
+import { Button } from "react-bootstrap";
+import { PREFIX } from "../../hooks/useLocalStorage";
+import { useDispatch } from "react-redux";
+import { updateUserAsync } from "../../../../Redux/features/user/userSlice";
+import { useEffect } from "react";
 
 function ChatDashboard({ id }) {
   const { selectedConversation } = useConversations();
+  const dispatch = useDispatch();
+
+  const chatBackup = () => {
+    const conversationsLS = JSON.parse(
+      localStorage.getItem(`${PREFIX}-conversations`)
+    );
+    const contactsLS = JSON.parse(localStorage.getItem(`${PREFIX}-contacts`));
+
+    const reqBody = {
+      chat: {
+        conversations: conversationsLS,
+        contacts: contactsLS,
+      },
+    };
+
+    dispatch(updateUserAsync(reqBody));
+  };
+
+  // save chat data when components unmounts
+  useEffect(() => {
+    return () => {
+      chatBackup();
+    };
+  }, []);
 
   return (
-    <div className="d-flex" style={{ height: "70vh" }}>
-      <Sidebar id={id} />
-      {selectedConversation && <OpenConversation />}
-    </div>
+    <>
+      <div className="d-flex justify-content-end">
+        <Button
+          style={{ marginLeft: "200px" }}
+          variant="outline-secondary"
+          size="sm"
+          onClick={chatBackup}
+        >
+          save chat
+        </Button>
+      </div>
+      <div className="d-flex" style={{ height: "70vh" }}>
+        <Sidebar id={id} />
+        {selectedConversation && <OpenConversation />}
+      </div>
+    </>
   );
 }
 export default ChatDashboard;

--- a/src/components/ChatApp/contexts/ContactsProvider.jsx
+++ b/src/components/ChatApp/contexts/ContactsProvider.jsx
@@ -2,6 +2,7 @@
 /* eslint-disable react/prop-types */
 import { createContext, useContext } from "react";
 import useLocalStorage from "../hooks/useLocalStorage";
+import { useSelector } from "react-redux";
 
 const ContactsContext = createContext();
 
@@ -10,7 +11,9 @@ export function useContacts() {
 }
 
 export function ContactsProvider({ children }) {
-  const [contacts, setContacts] = useLocalStorage("contacts", []);
+  const { chatContacts } = useSelector((store) => store.user);
+
+  const [contacts, setContacts] = useLocalStorage("contacts", chatContacts);
 
   function createContact(id, name) {
     setContacts((prev) => {

--- a/src/components/ChatApp/contexts/ConversationsProvider.jsx
+++ b/src/components/ChatApp/contexts/ConversationsProvider.jsx
@@ -10,6 +10,7 @@ import {
 import useLocalStorage from "../hooks/useLocalStorage";
 import { useContacts } from "./ContactsProvider";
 import { useSocket } from "./SocketProvider";
+import { useSelector } from "react-redux";
 
 const ConversationsContext = createContext();
 
@@ -18,9 +19,11 @@ export function useConversations() {
 }
 
 export function ConversationsProvider({ id, children }) {
+  const { chatConversations } = useSelector((store) => store.user);
+
   const [conversations, setConversations] = useLocalStorage(
     "conversations",
-    []
+    chatConversations
   );
   const [selectedConversationIndex, setSelectedConversationIndex] = useState(0);
   const { contacts } = useContacts();

--- a/src/components/ChatApp/hooks/useLocalStorage.js
+++ b/src/components/ChatApp/hooks/useLocalStorage.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-const PREFIX = "PAQUERGO-chat";
+export const PREFIX = "PAQUERGO-chat";
 export default function useLocalStorage(key, initialValue) {
   const prefixedKey = `${PREFIX}-${key}`;
   // console.log("INSIDE local", key, initialValue);

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -52,6 +52,9 @@ export default function Dashboard() {
   // fetch wastes and pacas
   React.useEffect(() => {
     dispatch(getUserWasteAsync());
+    localStorage.removeItem("PAQUERGO-chat-id");
+    localStorage.removeItem("PAQUERGO-chat-contacts");
+    localStorage.removeItem("PAQUERGO-chat-conversations");
   }, []);
 
   return (


### PR DESCRIPTION
1. chat contacts and conversations added to userSlice.
2. chat logs are loaded after the user logs in.
3. chat logs can be updated, manually within the chat app, by clicking the save chat button.
4. also chat is backup when chat component is dismounted, via a useEffect return callback.
5. local storage is cleared when user logs in.